### PR TITLE
Create the GrammarStatusView. Pull out of status bar

### DIFF
--- a/lib/grammar-selector-view.coffee
+++ b/lib/grammar-selector-view.coffee
@@ -1,0 +1,61 @@
+{_, $$, Editor, SelectList} = require 'atom'
+
+module.exports =
+class GrammarSelector extends SelectList
+  @viewClass: -> "#{super} grammar-selector from-top overlay"
+
+  filterKey: 'name'
+
+  initialize: ->
+    @editor = atom.rootView.getActiveView()
+    return unless @editor instanceof Editor
+    @list.addClass('mark-active') # TODO: there may be a better way to specify this.
+    @currentGrammar = @editor.getGrammar()
+    @autoDetect = name: 'Auto Detect'
+    @currentGrammar = @autoDetect if @currentGrammar is atom.syntax.nullGrammar
+    @path = @editor.getPath()
+    @command 'grammar-selector:show', =>
+      @cancel()
+      false
+    super
+
+    @populate()
+    @attach()
+
+  itemForElement: (grammar) ->
+    grammarClass = ''
+    grammarClass = 'active' if grammar is @currentGrammar
+
+    $$ ->
+      @li grammar.name, class: grammarClass
+
+  populate: ->
+    grammars = new Array(atom.syntax.grammars...)
+    grammars = _.reject grammars, (grammar) -> grammar is atom.syntax.nullGrammar
+    grammars.sort (grammarA, grammarB) ->
+      if grammarA.scopeName is 'text.plain'
+        -1
+      else if grammarB.scopeName is 'text.plain'
+        1
+      else if grammarA.name < grammarB.name
+        -1
+      else if grammarA.name > grammarB.name
+        1
+      else
+        0
+    grammars.unshift(@autoDetect)
+    @setArray(grammars)
+
+  confirmed: (grammar) ->
+    @cancel()
+    if grammar is @autoDetect
+      atom.syntax.clearGrammarOverrideForPath(@path)
+    else
+      atom.syntax.setGrammarOverrideForPath(@path, grammar.scopeName)
+    @editor.reloadGrammar()
+
+  attach: ->
+    super
+
+    atom.rootView.append(this)
+    @miniEditor.focus()

--- a/lib/grammar-selector.coffee
+++ b/lib/grammar-selector.coffee
@@ -1,65 +1,17 @@
-{_, $$, Editor, SelectList} = require 'atom'
+GrammarStatusView = require './grammar-status-view'
+GrammarSelectorView = require './grammar-selector-view'
 
 module.exports =
-class GrammarSelector extends SelectList
-  @viewClass: -> "#{super} grammar-selector from-top overlay"
-
-  @activate: ->
+  activate: ->
     atom.rootView.command 'grammar-selector:show', '.editor', =>
-      new GrammarSelector()
+      new GrammarSelectorView()
 
-  filterKey: 'name'
+    createStatusEntry = ->
+      view = new GrammarStatusView(atom.rootView.statusBar)
+      atom.rootView.statusBar.appendLeft(view)
 
-  initialize: ->
-    @editor = atom.rootView.getActiveView()
-    return unless @editor instanceof Editor
-    @list.addClass('mark-active') # TODO: there may be a better way to specify this.
-    @currentGrammar = @editor.getGrammar()
-    @autoDetect = name: 'Auto Detect'
-    @currentGrammar = @autoDetect if @currentGrammar is atom.syntax.nullGrammar
-    @path = @editor.getPath()
-    @command 'grammar-selector:show', =>
-      @cancel()
-      false
-    super
-
-    @populate()
-    @attach()
-
-  itemForElement: (grammar) ->
-    grammarClass = ''
-    grammarClass = 'active' if grammar is @currentGrammar
-
-    $$ ->
-      @li grammar.name, class: grammarClass
-
-  populate: ->
-    grammars = new Array(atom.syntax.grammars...)
-    grammars = _.reject grammars, (grammar) -> grammar is atom.syntax.nullGrammar
-    grammars.sort (grammarA, grammarB) ->
-      if grammarA.scopeName is 'text.plain'
-        -1
-      else if grammarB.scopeName is 'text.plain'
-        1
-      else if grammarA.name < grammarB.name
-        -1
-      else if grammarA.name > grammarB.name
-        1
-      else
-        0
-    grammars.unshift(@autoDetect)
-    @setArray(grammars)
-
-  confirmed: (grammar) ->
-    @cancel()
-    if grammar is @autoDetect
-      atom.syntax.clearGrammarOverrideForPath(@path)
+    if atom.rootView.statusBar
+      createStatusEntry()
     else
-      atom.syntax.setGrammarOverrideForPath(@path, grammar.scopeName)
-    @editor.reloadGrammar()
-
-  attach: ->
-    super
-
-    atom.rootView.append(this)
-    @miniEditor.focus()
+      atom.packages.once 'activated', ->
+        createStatusEntry()

--- a/lib/grammar-status-view.coffee
+++ b/lib/grammar-status-view.coffee
@@ -1,0 +1,29 @@
+{View} = require 'atom'
+
+module.exports =
+class GrammarStatusView extends View
+  @content: ->
+    @a href: '#', class: 'grammar-name inline-block'
+
+  initialize: (@statusBar) ->
+    @subscribe @statusBar, 'active-buffer-changed', @updateGrammarText
+
+    @subscribe this, 'click', => @getActiveView().trigger('grammar-selector:show'); false
+    @subscribe atom.rootView, 'editor:grammar-changed', @updateGrammarText
+
+  afterAttach: ->
+    @updateGrammarText()
+
+  getActiveView: ->
+    atom.rootView.getActiveView()
+
+  updateGrammarText: =>
+    grammar = @getActiveView()?.getGrammar?()
+    if grammar?
+      if grammar is atom.syntax.nullGrammar
+        grammarName = 'Plain Text'
+      else
+        grammarName = grammar.name
+      @text(grammarName).show()
+    else
+      @hide()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.9.0",
   "main": "./lib/grammar-selector",
   "description": "Select the grammar to use for the current editor.",
-  "activationEvents": "grammar-selector:show",
   "repository": {
     "type": "git",
     "url": "https://github.com/atom/grammar-selector.git"


### PR DESCRIPTION
Use the status-bar api to add the selector link to the status bar. This seems to be the first time one package is reliant on another package. Couple things: 
### I dont like the method of waiting for the status bar.

The grammar selector could be activated before the status bar. So I have this:

``` coffeescript
createStatusEntry = ->
  view = new GrammarStatusView(atom.rootView.statusBar)
  atom.rootView.statusBar.appendLeft(view)

if atom.rootView.statusBar
  createStatusEntry()
else
  atom.packages.once 'activated', ->
    createStatusEntry()
```

Would be nice to put something in the package manager or the root view to make this easier. The status-bar can put it in the rootView? Not sure what that looks like yet.
### Testing the addition to the status bar

I cant load the status-bar package from the specs (though it will load the language grammars, so maybe something else is going on??). So I am mocking the status bar. Not a huge amount of code, but it would be nice to use the real one in case of api or behavior changes. How do you guys feel about using the real package vs using a mock??
