### PR TITLE
div surround status-bar-view and add title to link

### DIFF
--- a/lib/grammar-status-view.coffee
+++ b/lib/grammar-status-view.coffee
@@ -5,7 +5,7 @@ module.exports =
 class GrammarStatusView extends View
   @content: ->
     @div class: 'grammar-status', =>
-      @a href: '#', class: 'inline-block'
+      @a href: '#', class: 'inline-block', outlet: 'grammarLink'
 
   initialize: (@statusBar) ->
     @subscribe @statusBar, 'active-buffer-changed', =>
@@ -38,9 +38,8 @@ class GrammarStatusView extends View
         grammarName = 'Plain Text'
       else
         grammarName = grammar.name ? grammar.scopeName
-      @children()
+      @grammarLink
         .text(grammarName)
         .attr('title', grammarName)
-        .show()
     else
       @hide()


### PR DESCRIPTION
Adding a div provides better separation, easier stylesheet selection, and more consistency with other status-bar elements. Also added a title to the link for a hover tooltip and for a unique stylesheet attribute.
