### PR TITLE
Access status bar through new service API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/grammar-status-view.coffee
+++ b/lib/grammar-status-view.coffee
@@ -7,12 +7,15 @@ class GrammarStatusView extends HTMLElement
     @grammarLink.href = '#'
     @appendChild(@grammarLink)
     @handleEvents()
+    this
 
   attach: ->
-    if atom.config.get 'grammar-selector.showOnRightSideOfStatusBar'
-      @statusBar.prependRight(this)
-    else
-      @statusBar.appendLeft(this)
+    @statusBarTile?.destroy()
+    @statusBarTile =
+      if atom.config.get 'grammar-selector.showOnRightSideOfStatusBar'
+        @statusBar.addRightTile(item: this)
+      else
+        @statusBar.addLeftTile(item: this)
 
   handleEvents: ->
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
@@ -34,7 +37,7 @@ class GrammarStatusView extends HTMLElement
     @grammarSubscription?.dispose()
     @clickSubscription?.dispose()
     @configSubscription?.off()
-    @remove()
+    @statusBarTile.destroy()
 
   getActiveTextEditor: ->
     atom.workspace.getActiveTextEditor()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,7 +6,11 @@ module.exports =
 
   activate: ->
     atom.workspaceView.command('grammar-selector:show', createGrammarListView)
-    atom.packages.once('activated', createGrammarStatusView)
+
+    atom.services.consume "status-bar", "^0.50.0", (statusBar) ->
+      GrammarStatusView = require './grammar-status-view'
+      grammarStatusView = new GrammarStatusView().initialize(statusBar)
+      grammarStatusView.attach()
 
   deactivate: ->
     grammarStatusView?.destroy()
@@ -17,11 +21,3 @@ createGrammarListView = ->
     GrammarListView = require './grammar-list-view'
     view = new GrammarListView(editor)
     view.attach()
-
-createGrammarStatusView = ->
-  {statusBar} = atom.workspaceView
-  if statusBar?
-    GrammarStatusView = require './grammar-status-view'
-    grammarStatusView = new GrammarStatusView()
-    grammarStatusView.initialize(statusBar)
-    grammarStatusView.attach()

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "repository": "https://github.com/atom/grammar-selector",
   "engines": {
     "atom": "*"
+  },
+  "dependencies": {
+    "underscore-plus": "^1.6.1"
   }
 }


### PR DESCRIPTION
:warning: WIP :warning:

This depends on atom/status-bar#43 being merged, released, and bumped in core. I'm opening this now to show an example of consuming a service with the new service API.
