### PR TITLE
New version for status-bar Services API

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "consumedServices": {
     "status-bar": {
       "versions": {
-        "^0.58.0": "consumeStatusBar"
+        "^1.0.0": "consumeStatusBar"
       }
     }
   }


### PR DESCRIPTION
Start using the new Service API versioning for `status-bar`.

**Don’t merge until Atom 0.187**