### PR TITLE
Correct fixture version semver

### DIFF
--- a/spec/fixtures/language-with-no-name/package.json
+++ b/spec/fixtures/language-with-no-name/package.json
@@ -1,4 +1,4 @@
 {
   "name": "language-test",
-  "version": "1.0"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
This corrects the version number given in a fixture to be semver per https://github.com/atom/atom/pull/6645#issuecomment-100340178.