### PR TITLE
Add description for config setting

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,6 +7,7 @@ module.exports =
     showOnRightSideOfStatusBar:
       type: 'boolean'
       default: true
+      description: 'Show the active pane item\'s langauge on the right side of Atom\'s status bar, instead of the left.'
 
   activate: ->
     commandDisposable = atom.commands.add('atom-text-editor', 'grammar-selector:show', createGrammarListView)


### PR DESCRIPTION
As a followup to atom/atom#9096, this adds descriptions for config settings in this package.
