### PR TITLE
Hide grammars without associated file extensions

### DIFF
--- a/lib/grammar-list-view.coffee
+++ b/lib/grammar-list-view.coffee
@@ -54,8 +54,9 @@ class GrammarListView extends SelectListView
       @attach()
 
   getGrammars: ->
+    showAll = atom.config.get 'grammar-selector.showAll'
     grammars = atom.grammars.getGrammars().filter (grammar) ->
-      grammar isnt atom.grammars.nullGrammar
+      grammar isnt atom.grammars.nullGrammar and (showAll isnt true or grammar.fileTypes.length > 0)
 
     grammars.sort (grammarA, grammarB) ->
       if grammarA.scopeName is 'text.plain'

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
       "type": "boolean",
       "default": true,
       "description": "Show the active pane item's langauge on the right side of Atom's status bar, instead of the left."
+    },
+    "showAll": {
+      "type": "boolean",
+      "default": false,
+      "description": "Some grammars only exist to be embedded inside others, such as regular expressions. Enable this option to show these grammars in the selection menu."
     }
   }
 }


### PR DESCRIPTION
As explained in issue #30 (which this PR addresses), some grammars only exist to be embedded inside other grammars (as determined by an empty `fileTypes` array). This commit hides those languages from the selection menu, unless the user enables a new package option to display everything:

<img width="440" alt="Figure 1" src="https://cloud.githubusercontent.com/assets/2346707/15087887/b8827848-1430-11e6-8e9d-2a0e7db5cb42.png" />