### PR TITLE
Use new TextEditorRegistry APIs for setting grammars

### DIFF
--- a/lib/grammar-list-view.coffee
+++ b/lib/grammar-list-view.coffee
@@ -31,12 +31,19 @@ class GrammarListView extends SelectListView
     @currentGrammar = null
 
   confirmed: (grammar) ->
-    if grammar is @autoDetect
-      atom.grammars.clearGrammarOverrideForPath(@editor.getPath())
-      @editor.reloadGrammar()
+    # TODO: remove this conditional once
+    if atom.textEditors.setGrammarOverride?
+      if grammar is @autoDetect
+        atom.textEditors.clearGrammarOverride(@editor)
+      else
+        atom.textEditors.setGrammarOverride(@editor, grammar.scopeName)
     else
-      atom.grammars.setGrammarOverrideForPath(@editor.getPath(), grammar.scopeName)
-      @editor.setGrammar(grammar)
+      if grammar is @autoDetect
+        atom.grammars.clearGrammarOverrideForPath(@editor.getPath())
+        @editor.reloadGrammar()
+      else
+        atom.grammars.setGrammarOverrideForPath(@editor.getPath(), grammar.scopeName)
+        @editor.setGrammar(grammar)
     @cancel()
 
   attach: ->

--- a/lib/grammar-list-view.coffee
+++ b/lib/grammar-list-view.coffee
@@ -31,7 +31,7 @@ class GrammarListView extends SelectListView
     @currentGrammar = null
 
   confirmed: (grammar) ->
-    # TODO: remove this conditional once
+    # TODO: remove this conditional once Atom v1.11.0 has been out for a while.
     if atom.textEditors.setGrammarOverride?
       if grammar is @autoDetect
         atom.textEditors.clearGrammarOverride(@editor)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grammar-selector",
-  "version": "0.48.1",
+  "version": "0.48.2-0",
   "main": "./lib/main",
   "description": "Select the grammar to use for the current editor with `ctrl-shift-L`.",
   "license": "MIT",

--- a/spec/grammar-selector-spec.coffee
+++ b/spec/grammar-selector-spec.coffee
@@ -104,7 +104,7 @@ describe "GrammarSelector", ->
       editor.setGrammar(atom.grammars.nullGrammar)
       expect(grammarStatus).toBeVisible()
       expect(grammarStatus.grammarLink.textContent).toBe 'Plain Text'
-      editor.reloadGrammar()
+      editor.setGrammar(atom.grammars.grammarForScopeName('source.js'))
       expect(grammarStatus).toBeVisible()
       expect(grammarStatus.grammarLink.textContent).toBe 'JavaScript'
 
@@ -131,12 +131,10 @@ describe "GrammarSelector", ->
 
     describe "when the editor's grammar changes", ->
       it "displays the new grammar of the editor", ->
-        atom.grammars.setGrammarOverrideForPath(editor.getPath(), 'text.plain')
-        editor.reloadGrammar()
+        editor.setGrammar(atom.grammars.grammarForScopeName('text.plain'))
         expect(grammarStatus.grammarLink.textContent).toBe 'Plain Text'
 
-        atom.grammars.setGrammarOverrideForPath(editor.getPath(), 'source.a')
-        editor.reloadGrammar()
+        editor.setGrammar(atom.grammars.grammarForScopeName('source.a'))
         expect(grammarStatus.grammarLink.textContent).toBe 'source.a'
 
     describe "when clicked", ->


### PR DESCRIPTION
~~Depends on https://github.com/atom/atom/pull/12125.~~

I did this in a backwards compatible way. It checks for the existence of `atom.textEditors.setGrammarOverride`.