### PR TITLE
Added scopeNames to the grammar modal

### DIFF
--- a/lib/grammar-list-view.js
+++ b/lib/grammar-list-view.js
@@ -17,6 +17,17 @@ export default class GrammarListView {
         }
         element.textContent = grammarName
         element.dataset.grammar = grammarName
+
+        const div = document.createElement('div')
+        div.classList.add('pull-right')
+        if (grammar.scopeName) {
+          const scopeName = document.createElement('scopeName')
+          scopeName.classList.add('key-binding') // It will be styled the same as the keybindings in the command palette
+          scopeName.textContent = grammar.scopeName
+          div.appendChild(scopeName)
+          element.appendChild(div)
+        }
+
         return element
       },
       didConfirmSelection: (grammar) => {


### PR DESCRIPTION
### Description of the Change

[It came up on the forum](https://discuss.atom.io/t/how-to-replace-a-keymap-binding/16834/25), so I decided that it would be cool if the grammar selector also displayed the `scopeName` for each grammar. This would make it much more convenient for someone to identify the scope selector of a given language than having to go to `Settings`, `Packages`, wait for the package list to load, and then the package settings page. So I did it.

http://puu.sh/toDVZ/02f699229f.png

### Alternate Designs

I used precisely the same method as is used to display keybindings in the Command Palette, so that the appearance of the two modals will be consistent. I didn't consider any alternatives.

### Benefits

Centralized `scopeName`s, less work for someone to figure out which selector they need for an entry in `config.cson`, `snippets.cson`, or `styles.less`.

### Possible Drawbacks

I can't conceive of any.