### PR TITLE
add a tooltip to the status bar display

### DIFF
--- a/lib/grammar-status-view.js
+++ b/lib/grammar-status-view.js
@@ -51,6 +51,10 @@ class GrammarStatusView {
     if (this.tile) {
       this.tile.destroy()
     }
+
+    if (this.tooltip) {
+      this.tooltip.destroy()
+    }
   }
 
   subscribeToActiveTextEditor () {
@@ -70,6 +74,12 @@ class GrammarStatusView {
     atom.views.updateDocument(() => {
       const editor = atom.workspace.getActiveTextEditor()
       const grammar = editor ? editor.getGrammar() : null
+
+      if (this.tooltip) {
+        this.tooltip.dispose()
+        this.tooltip = null
+      }
+
       if (grammar) {
         let grammarName = null
         if (grammar === atom.grammars.nullGrammar) {
@@ -81,6 +91,8 @@ class GrammarStatusView {
         this.grammarLink.textContent = grammarName
         this.grammarLink.dataset.grammar = grammarName
         this.element.style.display = ''
+
+        this.tooltip = atom.tooltips.add(this.element, {title: `File uses the ${grammarName} grammar`})
       } else {
         this.element.style.display = 'none'
       }

--- a/spec/grammar-selector-spec.js
+++ b/spec/grammar-selector-spec.js
@@ -114,6 +114,7 @@ describe('GrammarSelector', () => {
 
     it('displays the name of the current grammar', () => {
       expect(grammarStatus.querySelector('a').textContent).toBe('JavaScript')
+      expect(getTooltipText(grammarStatus)).toBe('File uses the JavaScript grammar')
     })
 
     it('displays Plain Text when the current grammar is the null grammar', async () => {
@@ -122,6 +123,7 @@ describe('GrammarSelector', () => {
 
       expect(grammarStatus.querySelector('a').textContent).toBe('Plain Text')
       expect(grammarStatus).toBeVisible()
+      expect(getTooltipText(grammarStatus)).toBe('File uses the Plain Text grammar')
 
       editor.setGrammar(atom.grammars.grammarForScopeName('source.js'))
       await atom.views.getNextUpdatePromise()
@@ -161,11 +163,13 @@ describe('GrammarSelector', () => {
         await atom.views.getNextUpdatePromise()
 
         expect(grammarStatus.querySelector('a').textContent).toBe('Plain Text')
+        expect(getTooltipText(grammarStatus)).toBe('File uses the Plain Text grammar')
 
         editor.setGrammar(atom.grammars.grammarForScopeName('source.a'))
         await atom.views.getNextUpdatePromise()
 
         expect(grammarStatus.querySelector('a').textContent).toBe('source.a')
+        expect(getTooltipText(grammarStatus)).toBe('File uses the source.a grammar')
       })
     )
 
@@ -187,3 +191,8 @@ describe('GrammarSelector', () => {
     )
   })
 })
+
+function getTooltipText (element) {
+  const [tooltip] = atom.tooltips.findTooltips(element)
+  return tooltip.getTitle()
+}


### PR DESCRIPTION
### Requirements

### Description of the Change

This PR adds a tooltip to the status bar display.

![image](https://cloud.githubusercontent.com/assets/1776/24788440/6573b7bc-1b22-11e7-8312-9b573c0010c0.png)

### Alternate Designs

No other designs were considered.

### Benefits

Helps the user understand that this display is only referring to the highlighting of the current file.

### Possible Drawbacks

A little more code and another thing to potentially leak.

### Applicable Issues

Inspired by https://github.com/atom/encoding-selector/issues/26.

Similar to https://github.com/atom/encoding-selector/pull/45 and https://github.com/atom/line-ending-selector/pull/42