### PR TITLE
Restore ability to display grammar for pending text editor panes

### DIFF
--- a/lib/grammar-status-view.js
+++ b/lib/grammar-status-view.js
@@ -10,7 +10,7 @@ export default class GrammarStatusView {
     this.grammarLink = document.createElement('a')
     this.grammarLink.classList.add('inline-block')
     this.element.appendChild(this.grammarLink)
-    this.activeItemSubscription = atom.workspace.observeActivePaneItem(this.subscribeToActiveTextEditor.bind(this))
+    this.activeItemSubscription = atom.workspace.observeActiveTextEditor(this.subscribeToActiveTextEditor.bind(this))
     this.configSubscription = atom.config.observe('grammar-selector.showOnRightSideOfStatusBar', this.attach.bind(this))
     const clickHandler = (event) => {
       event.preventDefault()

--- a/lib/grammar-status-view.js
+++ b/lib/grammar-status-view.js
@@ -10,7 +10,14 @@ export default class GrammarStatusView {
     this.grammarLink = document.createElement('a')
     this.grammarLink.classList.add('inline-block')
     this.element.appendChild(this.grammarLink)
-    this.activeItemSubscription = atom.workspace.observeActiveTextEditor(this.subscribeToActiveTextEditor.bind(this))
+
+    // TODO[v1.19]: Remove conditional once atom.workspace.observeActiveTextEditor ships in Atom v1.19
+    if (atom.workspace.observeActiveTextEditor) {
+      this.activeItemSubscription = atom.workspace.observeActiveTextEditor(this.subscribeToActiveTextEditor.bind(this))
+    } else {
+      this.activeItemSubscription = atom.workspace.observeActivePaneItem(this.subscribeToActiveTextEditor.bind(this))
+    }
+
     this.configSubscription = atom.config.observe('grammar-selector.showOnRightSideOfStatusBar', this.attach.bind(this))
     const clickHandler = (event) => {
       event.preventDefault()


### PR DESCRIPTION
### Description of the Change

As one part of resolving https://github.com/atom/status-bar/issues/194, this pull request updates this package to take advantage of the new `Workspace::observeActiveTextEditor(callback)` API being introduced in https://github.com/atom/atom/pull/14695.

### Alternate Designs

See https://github.com/atom/atom/pull/14695

### Benefits

The package will regain the ability to display the grammar for pending text editor panes.

### Possible Drawbacks

See https://github.com/atom/atom/pull/14695

### Applicable Issues

- https://github.com/atom/atom/issues/14648
- https://github.com/atom/status-bar/issues/194

### Demo

#### Before

![before](https://cloud.githubusercontent.com/assets/2988/26699994/c4e45c90-46e9-11e7-9e2e-47799b263d66.gif)


#### After

![after](https://cloud.githubusercontent.com/assets/2988/26699993/c4de1f74-46e9-11e7-9bae-ff7f8137485b.gif)
