### PR TITLE
Remove obsolete conditional re: `atom.workspace.observeActiveTextEditor`

### DIFF
--- a/lib/grammar-status-view.js
+++ b/lib/grammar-status-view.js
@@ -11,12 +11,7 @@ export default class GrammarStatusView {
     this.grammarLink.classList.add('inline-block')
     this.element.appendChild(this.grammarLink)
 
-    // TODO[v1.19]: Remove conditional once atom.workspace.observeActiveTextEditor ships in Atom v1.19
-    if (atom.workspace.observeActiveTextEditor) {
-      this.activeItemSubscription = atom.workspace.observeActiveTextEditor(this.subscribeToActiveTextEditor.bind(this))
-    } else {
-      this.activeItemSubscription = atom.workspace.observeActivePaneItem(this.subscribeToActiveTextEditor.bind(this))
-    }
+    this.activeItemSubscription = atom.workspace.observeActiveTextEditor(this.subscribeToActiveTextEditor.bind(this))
 
     this.configSubscription = atom.config.observe('grammar-selector.showOnRightSideOfStatusBar', this.attach.bind(this))
     const clickHandler = (event) => {


### PR DESCRIPTION
This PR removes the conditional logic (originally introduced in https://github.com/atom/grammar-selector/pull/45) that tested for the existence of `atom.workspace.observeActiveTextEditor`. Now that Atom 1.19 has been released, we can safely expect `atom.workspace.observeActiveTextEditor` to be available: https://github.com/atom/atom/blob/v1.19.0/src/workspace.js#L689-L702
